### PR TITLE
Configure privilege escalation

### DIFF
--- a/tasks/amazon_linux.yaml
+++ b/tasks/amazon_linux.yaml
@@ -1,0 +1,3 @@
+---
+- name: Amazon Linux 2 | Configure privilege escalation
+  include_tasks: configure_privilege_escalation_al2.yaml

--- a/tasks/configure_privilege_escalation_al2.yaml
+++ b/tasks/configure_privilege_escalation_al2.yaml
@@ -1,0 +1,88 @@
+---
+# Ensure sudo package is installed
+- name: Ensure sudo is installed
+  become: true
+  ansible.builtin.package:
+    name: "{{ sudo_package }}"
+    state: present
+
+# Ensure sudo commands use pty
+- name: Check if 'Defaults use_pty' is configured
+  become: true
+  ansible.builtin.shell: |
+    grep -rPi "^\h*Defaults\h+([^#\n\r]+,)?use_pty(,\h*\h+\h*)*\h*(#.*)?$" {{ sudoers_path }} 2>/dev/null || true
+  register: use_pty_check
+  changed_when: false
+  failed_when: false
+
+- name: Add 'Defaults use_pty' if not present
+  become: true
+  ansible.builtin.lineinfile:
+    path: "{{ sudoers_path }}"
+    regexp: '^\s*Defaults\s+.*use_pty'
+    line: 'Defaults use_pty'
+    validate: '/usr/sbin/visudo -cf %s'
+  when: use_pty_check.stdout == ""
+
+# Ensure sudo log file exists
+- name: Check if sudo logfile is configured
+  become: true
+  ansible.builtin.shell: |
+    grep -rPsi "^\h*Defaults\h+([^#]+,\h*)?logfile\h*=\h*(\"|\')?\H+(\"|\')?(,\h*\H+\h*)*\h*(#.*)?$" {{ sudoers_path }} 2>/dev/null || true
+  register: sudo_logfile_check
+  changed_when: false
+  failed_when: false
+
+- name: Add Defaults logfile entry if missing
+  become: true
+  ansible.builtin.lineinfile:
+    path: "{{ sudoers_path }}"
+    regexp: '^\s*Defaults\s+.*logfile='
+    line: 'Defaults logfile="{{ sudo_logfile_path }}"'
+    validate: '/usr/sbin/visudo -cf %s'
+  when: sudo_logfile_check.stdout == ""
+
+# Ensure re-authentication for privilege escalation is not disabled globally
+- name: Check for '!authenticate' entries
+  become: true
+  ansible.builtin.shell: |
+    grep -r "^[^#].*\!authenticate" {{ sudoers_path }} 2>/dev/null || true
+  register: no_authenticate_check
+  changed_when: false
+  failed_when: false
+
+- name: Remove '!authenticate' entries if found
+  become: true
+  ansible.builtin.replace:
+    path: "{{ sudoers_path }}"
+    regexp: '(!authenticate)'
+    replace: ''
+    validate: '/usr/sbin/visudo -cf %s'
+  when: no_authenticate_check.stdout != ""
+
+# Ensure sudo authentication timestamp timeout is configured
+- name: Set sudo timestamp_timeout to policy value
+  become: true
+  ansible.builtin.lineinfile:
+    path: "{{ sudoers_path }}"
+    regexp: '^\s*Defaults\s+.*timestamp_timeout='
+    line: 'Defaults timestamp_timeout={{ timestamp_timeout_minutes }}'
+    insertafter: '^Defaults'
+    validate: '/usr/sbin/visudo -cf %s'
+
+# Ensure access to the 'su' command is restricted
+- name: Create group for su access restriction
+  become: true
+  ansible.builtin.group:
+    name: "{{ su_group_name }}"
+    state: present
+
+- name: Restrict su command to group members
+  become: true
+  ansible.builtin.lineinfile:
+    path: "{{ pam_su_path }}"
+    regexp: '^auth\s+required\s+pam_wheel\.so'
+    line: "auth required pam_wheel.so use_uid group={{ su_group_name }}"
+    create: false
+    backrefs: false
+

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -2,15 +2,18 @@
 - name: Include CIS Stage Specific vars
   include_vars: cis-{{ cis_Stage }}.yaml
 
-- name: Debian realted Specification
+- name: Debian related Specification
   include_tasks: configure_Debian.yaml
   when:
     ansible_os_family == 'Debian'
 
-- name: Centos realted Specification
+- name: CentOS related Specification
   include_tasks: configure_RedHat.yaml
-  when:
-    ansible_os_family == 'RedHat'
+  when: ansible_os_family == 'RedHat' and ansible_distribution != 'Amazon'
+
+- name: Amazon Linux 2 related Specification
+  include_tasks: amazon_linux.yaml
+  when: ansible_distribution == 'Amazon'
 
 # - name: Special purpose services
 #   include_tasks: services.yaml
@@ -35,3 +38,4 @@
 
 # - name: Ensure dccp and sctp is disabled
 #   include_tasks: network_protocol_and_unusedFilesystem.yaml
+

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -88,3 +88,12 @@ os_services_name: ['avahi-daemon', 'slapd', 'named', 'cups', 'telnet', 'discard-
 # aide cronjob configuration
 minute_aide_cronjob: '0'
 hour_aide_cronjob: '5'
+
+#Configure privilege escalation
+sudo_package: "sudo"
+sudoers_path: "/etc/sudoers"
+sudo_logfile_path: "/var/log/sudo.log"
+timestamp_timeout_minutes: 15
+su_group_name: "sugroup"
+pam_su_path: "/etc/pam.d/su"
+


### PR DESCRIPTION
Added automated tasks to enforce CIS privilege-escalation settings, including ensuring sudo is installed, enforcing use_pty, configuring a sudo logfile, removing !authenticate, setting a 15-minute authentication timeout, and restricting su access to a designated group.