### PR TITLE
Filesystem kernel modules al2

### DIFF
--- a/tasks/amazon_linux.yaml
+++ b/tasks/amazon_linux.yaml
@@ -23,3 +23,5 @@
   include_tasks: configure_filesystem_partitions_al2.yaml
 - name: Amazon Linux 2 | Configure Logging (rsyslog + journald)
   include_tasks: configure_logging_al2.yaml
+- name: Amazon Linux 2 | Disable kernal module
+  include_tasks: filesystem_kernel_modules_al2.yaml

--- a/tasks/filesystem_kernel_modules_al2.yaml
+++ b/tasks/filesystem_kernel_modules_al2.yaml
@@ -1,0 +1,43 @@
+---
+# Check if modules exist
+- name: Check if modules exist on system
+  ansible.builtin.command: modprobe -n -v {{ item }}
+  register: module_check
+  loop: "{{ fs_modules }}"
+  failed_when: false
+  changed_when: false
+
+# Build module existence map
+- name: Build module existence lookup table
+  ansible.builtin.set_fact:
+    mod_exists: "{{ mod_exists | default({}) | combine({item.item: item.rc}) }}"
+  loop: "{{ module_check.results }}"
+  loop_control:
+    loop_var: item
+    label: "{{ item.item }}"
+
+# Apply blacklist and install rules
+- name: Disable filesystem modules (install + blacklist)
+  ansible.builtin.copy:
+    dest: "/etc/modprobe.d/{{ item }}.conf"
+    content: |
+      install {{ item }} /bin/false
+      blacklist {{ item }}
+    mode: "0644"
+  when: mod_exists[item] == 0
+  loop: "{{ fs_modules }}"
+
+# Check loaded modules
+- name: Check loaded modules
+  ansible.builtin.command: lsmod
+  register: lsmod_output
+  failed_when: false
+  changed_when: false
+
+# Unload loaded modules
+- name: Unload loaded modules
+  ansible.builtin.command: modprobe -r {{ item }}
+  when: item in lsmod_output.stdout
+  failed_when: false
+  loop: "{{ fs_modules }}"
+

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -206,4 +206,14 @@ shm_mount_options:
   - { name: "Ensure nosuid option set on /dev/shm", opts: "defaults,rw,nosuid,nodev,noexec,relatime" }
   - { name: "Ensure noexec option set on /dev/shm", opts: "defaults,rw,nosuid,nodev,noexec,relatime" }
 
+#Configure Filesystem Kernel Modules
+fs_modules:
+  - cramfs
+  - freevxfs
+  - hfs
+  - hfsplus
+  - jffs2
+  - udf
+  - squashfs
+  - usb-storage
 


### PR DESCRIPTION
Implements CIS 1.1.1 – Configure Filesystem Kernel Modules (AL2) by disabling unused filesystem and storage kernel modules (cramfs, freevxfs, hfs, hfsplus, jffs2, squashfs, udf, usb-storage).
Prevents loading of insecure or unnecessary filesystems to reduce attack surface.
Fully automated and CIS-compliant.