### PR TITLE
Configure iptables al2

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -69,3 +69,9 @@
   ansible.builtin.service:
     name: systemd-journal-upload.service
     state: restarted
+
+- name: Restart iptables
+  ansible.builtin.service:
+    name: iptables
+    state: restarted
+

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -77,6 +77,20 @@
     name: systemd-journal-upload.service
     state: restarted
 
+- name: yum_clean_metadata
+  ansible.builtin.command:
+    cmd: yum clean metadata
+  changed_when: true
+
+- name: yum_clean_all
+  ansible.builtin.command:
+    cmd: yum clean all
+  changed_when: true
+
+- name: patching_log
+  ansible.builtin.debug:
+    msg: "System packages updated successfully."
+
 - name: Restart iptables
   ansible.builtin.service:
     name: iptables

--- a/tasks/amazon_linux.yaml
+++ b/tasks/amazon_linux.yaml
@@ -35,5 +35,9 @@
   include_tasks: local_user_and_group_settings_al2.yaml
 - name: Amazon Linux 2 | Configure Logging (rsyslog + journald)
   include_tasks: configure_logging_al2.yaml
+- name: Amazon Linux 2 | Configure Software and Patch Management
+  include_tasks: configure_software_and_patch_management_al2.yaml
+- name: Amazon Linux 2 | Configure SSH Server
+  include_tasks: configure_ssh_server.yaml
 - name: Amazon Linux 2 | Configure iptables
   include_tasks: configure_iptables_al2.yml

--- a/tasks/amazon_linux.yaml
+++ b/tasks/amazon_linux.yaml
@@ -23,3 +23,5 @@
   include_tasks: configure_filesystem_partitions_al2.yaml
 - name: Amazon Linux 2 | Configure Logging (rsyslog + journald)
   include_tasks: configure_logging_al2.yaml
+- name: Amazon Linux 2 | Configure iptables
+  include_tasks: configure_iptables_al2.yml

--- a/tasks/configure_iptables_al2.yml
+++ b/tasks/configure_iptables_al2.yml
@@ -1,0 +1,25 @@
+---
+# Configure iptables (AL2)
+
+- name: Ensure iptables package is installed
+  ansible.builtin.package:
+    name: iptables-services
+    state: present
+
+# Ensure iptables service enabled and active
+- name: Ensure iptables service is enabled and running
+  ansible.builtin.service:
+    name: iptables
+    state: started
+    enabled: true
+
+# Deploy idempotent rules
+- name: Deploy CIS-compliant iptables rules
+  ansible.builtin.template:
+    src: iptables.rules.j2
+    dest: /etc/sysconfig/iptables
+    owner: root
+    group: root
+    mode: '0600'
+  notify: Restart iptables
+

--- a/templates/iptables.rules.j2
+++ b/templates/iptables.rules.j2
@@ -1,0 +1,26 @@
+*filter
+
+# Default policies
+:INPUT {{ iptables_default_policy.INPUT }} [0:0]
+:FORWARD {{ iptables_default_policy.FORWARD }} [0:0]
+:OUTPUT {{ iptables_default_policy.OUTPUT }} [0:0]
+
+# 3.4.4.2.1 – Allow loopback traffic
+-A INPUT -i lo -j ACCEPT
+-A INPUT -s 127.0.0.0/8 ! -i lo -j DROP
+
+# 3.4.4.2.2 – Allow established and related connections
+-A INPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+
+# 3.4.4.2.3 – Allow approved TCP ports
+{% for port in iptables_allowed_tcp_ports %}
+-A INPUT -p tcp --dport {{ port }} -m conntrack --ctstate NEW -j ACCEPT
+{% endfor %}
+
+# Allow approved UDP ports
+{% for port in iptables_allowed_udp_ports %}
+-A INPUT -p udp --dport {{ port }} -m conntrack --ctstate NEW -j ACCEPT
+{% endfor %}
+
+COMMIT
+

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -206,4 +206,15 @@ shm_mount_options:
   - { name: "Ensure nosuid option set on /dev/shm", opts: "defaults,rw,nosuid,nodev,noexec,relatime" }
   - { name: "Ensure noexec option set on /dev/shm", opts: "defaults,rw,nosuid,nodev,noexec,relatime" }
 
+# Approved inbound ports
+iptables_allowed_tcp_ports:
+  - 22   # SSH
+
+iptables_allowed_udp_ports: []
+
+# Default policies
+iptables_default_policy:
+  INPUT: DROP
+  FORWARD: DROP
+  OUTPUT: ACCEPT
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -322,8 +322,12 @@ shm_mount_options:
 # Approved inbound ports
 iptables_allowed_tcp_ports:
   - 22   # SSH
+  - 80
+  - 53
+  - 443
 
-iptables_allowed_udp_ports: []
+iptables_allowed_udp_ports:
+  - 53
 
 # Default policies
 iptables_default_policy:


### PR DESCRIPTION
Implements CIS 3.4.4.2 – Configure iptables (AL2) using an idempotent, template-based approach.
Configures loopback traffic, established connections, default deny policies, and persists rules.
Ensures iptables service is enabled and compliant with CIS recommendations.